### PR TITLE
Unlinked option "discard at startup" from auto discard

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -58,7 +58,10 @@
 			<input type="checkbox" id="batteryCheck" class='option' />
 			<label for="batteryCheck" class="cbLabel">Only auto-discard if running on battery</label>
 		</div>
-		<div class="formRow autoDiscardOption">
+		
+		<!-- autoDiscardOption is hidden whenever auto discard is turned off i.e. set to Never -->
+		<!-- This isn't related to auto discard, so it's not labeled as such -->
+		<div class="formRow">
 			<input type="checkbox" id="discardAtStartup" class='option' />
 			<label for="discardAtStartup" class="cbLabel">Discard all tabs at startup</label>
 		</div>


### PR DESCRIPTION
Removed `autoDiscardOption` from checkbox `discardAtStartup`
The option get's hidden when the discard timer is disabled, which is incorrect, in my opinion.

----

Hey there, I want to use the discard at startup feature without using the timed discard function. However, turning off auto discard(by setting the timer to *Never*) seems to hide the discard at startup function, which implies it's disabled. 

It turns out that this hiding feature is controlled by the HTML class `autoDiscardOption` and seems to be it's sole functionality. So, to prevent the option from hiding, I removed the class from the `discardAtStartup` option.

This is my first pull request, so please let me know if I should do anything differently or have other feedback .etc

Thank you!