### PR TITLE
chrome.{extension->runtime}.getURL

### DIFF
--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -165,7 +165,7 @@ function isSpecialTab(tab) {
 }
 
 var openTabManager = {
-  'options'   : { tabId:null, url:chrome.extension.getURL('html/options.html') },
+  'options'   : { tabId:null, url:chrome.runtime.getURL('html/options.html') },
   'discards'  : { tabId:null, url:'chrome://discards/' },
 }
 


### PR DESCRIPTION
This has been deprecated for a while, but made a hard change in MV3.